### PR TITLE
git-external: Support arbitrary pathspecs as branch

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -19,3 +19,9 @@
 	url = https://github.com/stettberger/ispositive.git
 	symlink = is-positive-git
 	vcs = git
+
+[external "is-positive-hash"]
+	path = is-positive-hash
+	url = https://github.com/stettberger/ispositive.git
+	branch = 92bb8b7949e3062d0768dcad0a493210782d8f6b
+	vcs = git

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ command has to be used.
     	only = update
     	vcs = git
 
+## Branches
+
+Within the `branch =` configuration, you cannot only give branch
+names, but also tag names. We use `git checkout` to guess what you
+want to checkout.
+
+On `update`, branches are not switched, even if the external
+definition has changed. If you want to be sure to switch to the
+configured branch, use `./git-external clone`.
+
 ## Overrides
 
 You can overide the settings for externals by putting an external

--- a/bin/git-external
+++ b/bin/git-external
@@ -3,7 +3,7 @@
 import os
 import re
 import sys
-from subprocess import check_output, check_call, call, CalledProcessError
+from subprocess import check_output, check_call, call, run, CalledProcessError
 from subprocess import DEVNULL
 from collections import defaultdict, namedtuple
 import urllib.request
@@ -238,27 +238,6 @@ class GitExternal:
 
         print("Added external %s\n  Don't forget to call init" % (path))
 
-    def switch_or_create_branch(self, path, branch):
-        """Switch to (created) branch in GITDIR=${path}"""
-        if not branch:
-            return
-        cur_branch = check_output(["git", "symbolic-ref", "--short", "HEAD"],
-                                  cwd=path)
-        cur_branch = cur_branch.decode().strip()
-        if cur_branch != branch:
-            # list of branches
-            # expected output:
-            # <hash> refs/heads/<branchname>
-            branches = check_output(["git", "show-ref", "--heads"], cwd=path)
-            branches = [line.split("/")[-1]
-                        for line in branches.decode().strip().split("\n")]
-            if branch in branches:
-                print(f"  Switch to branch: {branch} (from {cur_branch})")
-            else:
-                print(f"  Switch and create branch: {branch} (from {cur_branch}")
-                check_call(["git", "checkout", "-b", branch,
-                            "origin/" + branch], cwd=path)
-
     def is_repository(self, path: str) -> bool:
         """Check if path is a git or SVN repository."""
         return any([os.path.exists(os.path.join(path, x))
@@ -301,9 +280,13 @@ class GitExternal:
                     print("Updating Git SVN external: %s" % repo)
                     call(["svn", "up"], cwd=path)
                 else:
-                    print(f"Updating Git external: {repo}")
-                    self.switch_or_create_branch(path, config.get("branch"))
-                    call(["git", "pull", "--ff-only"], cwd=path)
+                    cur_branch = run(["git", "symbolic-ref", "--short", "HEAD"],
+                                     cwd=path, capture_output=True)
+                    if cur_branch.stdout.decode().strip() == config.get("branch"):
+                        print(f"Updating Git external: {repo}")
+                        call(["git", "pull", "--ff-only"], cwd=path)
+                    else:
+                        print(f"Skipping update of Git external: {repo}")
             elif 'clone' in repo_only and not self.is_repository(path):
                 # Clone that repo
                 if config.get("symlink"):
@@ -324,7 +307,10 @@ class GitExternal:
                 else:
                     print(f"Cloning Git external: {repo}")
                     check_call(["git", "clone", config["url"], path])
-                    self.switch_or_create_branch(path, config.get("branch"))
+                    branch = config.get("branch")
+                    print(f"  Switch to branch or tag: {branch}")
+                    check_call(["git", "checkout", branch],
+                               cwd=path)
             # recursively call for externals
             if (args.recursive and vcs in ['git', 'git-svn'] and
                     set(repo_only) & set(['clone', 'update'])):

--- a/bin/git-external
+++ b/bin/git-external
@@ -254,6 +254,13 @@ class GitExternal:
         return any([os.path.exists(os.path.join(path, x))
                     for x in ['.git', '.svn']])
 
+    def get_branch_name(self, path):
+        """Returns the current branch name or 'DETACHED'"""
+        cur_branch = run(["git", "symbolic-ref", "--short", "HEAD"],
+                         cwd=path, capture_output=True)
+        ret = cur_branch.stdout.decode().strip()
+        return ret or "DETACHED"
+
     def init_or_update(self, recursive=True, only=None, external=None):
         """Init or update all repositories in self.configurations.
 
@@ -285,19 +292,19 @@ class GitExternal:
             if 'update' in repo_only and self.is_repository(path):
                 # Update that external
                 if vcs == "git-svn":
-                    log.info(f"Updating GIT-SVN external: {repo}")
+                    log.info(f"[{repo}] Updating GIT-SVN external")
                     call(["git", "svn", "rebase"], cwd=path)
                 elif vcs == "svn":
-                    log.info("Updating Git SVN external: %s" % repo)
+                    log.info("[{repo}] Updating Git SVN external")
                     call(["svn", "up"], cwd=path)
                 else:
-                    cur_branch = run(["git", "symbolic-ref", "--short", "HEAD"],
-                                     cwd=path, capture_output=True)
-                    if cur_branch.stdout.decode().strip() == config.get("branch"):
-                        log.info(f"Updating Git external: {repo}")
+                    cur_branch = self.get_branch_name(path)
+                    branch = config.get("branch") or "master"
+                    if branch == cur_branch:
+                        log.info(f"[{repo}] Updating Git external")
                         call(["git", "pull", "--ff-only"], cwd=path)
                     else:
-                        log.warning(f"Skipping update, different branch checked out: {repo}")
+                        log.warning(f"[{repo}] Skipping update, different branch: {branch} != {cur_branch}")
             elif 'clone' in repo_only and not self.is_repository(path):
                 # Clone that repo
                 if config.get("symlink"):
@@ -308,22 +315,31 @@ class GitExternal:
                         os.unlink(path)
                     os.symlink(link, path)
                 elif vcs == "git-svn":
-                    log.info(f"Cloning Git SVN external: {repo}")
+                    log.info(f"[{repo}] Cloning Git SVN external")
                     check_call(["git", "svn", "clone", config["url"],
                                 path, "-r", "HEAD"])
                 elif vcs == "svn":
-                    log.info("Cloning SVN external: %s" % repo)
+                    log.info("[{repo}] Cloning SVN external")
                     check_call(["svn", "checkout", config["url"],
                                 path, ])
                 else:
-                    branch = config.get("branch")
-                    log.info(f"Cloning Git external: {repo} (branch: {branch})")
+                    branch = config.get("branch") or "master"
+                    log.info(f"[{repo}] Cloning Git external (branch: {branch})")
                     check_call(["git", "clone", config["url"],
                                 "--branch", branch, path])
+            elif 'clone' in repo_only and self.is_repository(path):
+                if vcs == "git":
+                    cur_branch = self.get_branch_name(path)
+                    branch = config.get('branch') or "master"
+                    if cur_branch != branch:
+                        log.info(f"[{repo}] Switching branch {cur_branch} -> {branch}")
+                        check_call(["git", "checkout", branch],
+                                   cwd=path)
+
             # recursively call for externals
             if (args.recursive and vcs in ['git', 'git-svn'] and
                     set(repo_only) & set(['clone', 'update'])):
-                log.info(f"Updating externals of {repo}")
+                log.info(f"[{repo}] Updating recursive externals")
                 ext = GitExternal(path=path)
                 ext.cmd_update(namedtuple('Args',
                                           ['recursive', 'automatic', 'external', 'only'])

--- a/bin/git-external
+++ b/bin/git-external
@@ -173,8 +173,7 @@ class GitExternal:
                        if self.configurations[x]['path'].startswith(path)]
             for match in matches:
                 del self.configurations[match]
-                log.warning(f"External '{repo}' is masking '{match}'.",
-                      file=sys.stderr)
+                log.warning(f"External '{repo}' is masking '{match}'")
             self.configurations[repo] = new_externals[repo]
 
     def load_configuration(self):
@@ -324,9 +323,15 @@ class GitExternal:
                                 path, ])
                 else:
                     branch = config.get("branch") or "master"
-                    log.info(f"[{repo}] Cloning Git external (branch: {branch})")
-                    check_call(["git", "clone", config["url"],
-                                "--branch", branch, path])
+                    log.info(f"[{repo}] Cloning Git external")
+                    check_call(["git", "clone", config["url"], path])
+
+                    cur_branch = self.get_branch_name(path)
+                    branch = config.get('branch') or "master"
+                    if cur_branch != branch:
+                        log.info(f"[{repo}] Switching branch {cur_branch} -> {branch}")
+                        check_call(["git", "checkout", branch], cwd=path)
+
             elif 'clone' in repo_only and self.is_repository(path):
                 if vcs == "git":
                     cur_branch = self.get_branch_name(path)

--- a/bin/git-external
+++ b/bin/git-external
@@ -258,7 +258,7 @@ class GitExternal:
         cur_branch = run(["git", "symbolic-ref", "--short", "HEAD"],
                          cwd=path, capture_output=True)
         ret = cur_branch.stdout.decode().strip()
-        return ret or "DETACHED"
+        return ret or None
 
     def init_or_update(self, recursive=True, only=None, external=None):
         """Init or update all repositories in self.configurations.
@@ -302,6 +302,8 @@ class GitExternal:
                     if branch == cur_branch:
                         log.info(f"[{repo}] Updating Git external")
                         call(["git", "pull", "--ff-only"], cwd=path)
+                    elif cur_branch is None:
+                        log.warning(f"[{repo}] Skipping update, detached HEAD")
                     else:
                         log.warning(f"[{repo}] Skipping update, different branch: {branch} != {cur_branch}")
             elif 'clone' in repo_only and not self.is_repository(path):

--- a/bin/git-external
+++ b/bin/git-external
@@ -14,6 +14,18 @@ import fnmatch
 import contextlib
 import argparse
 
+import logging
+try:
+    import coloredlogs
+    colors = coloredlogs.parse_encoded_styles("debug=green;info=green;warning=yellow,bold;error=red;critical=red,bold")
+    fields = coloredlogs.parse_encoded_styles("name=blue;levelname=white,bold")
+    coloredlogs.install(fmt="[%(name)s] %(levelname)s: %(message)s",
+                        level_styles=colors, field_styles=fields)
+except ImportError:
+    logging.basicConfig(level=logging.INFO)
+    pass
+log = logging.getLogger("git-external")
+
 defaulturl = "https://raw.githubusercontent.com/stettberger/git-external/master/bin/git-external"
 
 self_path = os.path.relpath(os.path.abspath(sys.argv[0]), ".")
@@ -83,12 +95,12 @@ class InitScript:
         file path.
         """
         url = self.config["external"].get("updateurl", defaulturl)
-        print(f"Fetching {url}")
+        log.info(f"Fetching {url}")
         with self._open_url(url) as x:
             update = x.read()
             with open(self_path, "wb+") as fd:
                 fd.write(update)
-        print(f"Updated {self_path}")
+        log.info(f"Updated {self_path}")
 
     @command_description
     def self_update(self, subparser):
@@ -103,7 +115,7 @@ class GitExternal:
                                          "--show-toplevel"], cwd=path)
             self.rootdir = self.rootdir.decode('utf-8').strip()
         except CalledProcessError as e:
-            print("Not a git directory", e)
+            log.critical("Not a git directory", e)
             sys.exit(1)
 
         self.externals_file = os.path.join(self.rootdir, ".gitexternals")
@@ -161,7 +173,7 @@ class GitExternal:
                        if self.configurations[x]['path'].startswith(path)]
             for match in matches:
                 del self.configurations[match]
-                print(f"External '{repo}' is masking '{match}'.",
+                log.warning(f"External '{repo}' is masking '{match}'.",
                       file=sys.stderr)
             self.configurations[repo] = new_externals[repo]
 
@@ -196,7 +208,6 @@ class GitExternal:
                     if pattern and attribute and fnmatch.fnmatch(attribute, pattern):
                         matches = True
                 if matches:
-                    # print(name, "matches", repo)
                     self.configurations[repo].update(
                         {k: v for (k, v) in config.items()
                          if not k.startswith('match-')})
@@ -236,7 +247,7 @@ class GitExternal:
         check_call(["git", "add", self.externals_file])
         check_call(["git", "add", self.ignore_file])
 
-        print("Added external %s\n  Don't forget to call init" % (path))
+        log.warning("Added external %s\n  Don't forget to call init" % (path))
 
     def is_repository(self, path: str) -> bool:
         """Check if path is a git or SVN repository."""
@@ -274,47 +285,45 @@ class GitExternal:
             if 'update' in repo_only and self.is_repository(path):
                 # Update that external
                 if vcs == "git-svn":
-                    print(f"Updating GIT-SVN external: {repo}")
+                    log.info(f"Updating GIT-SVN external: {repo}")
                     call(["git", "svn", "rebase"], cwd=path)
                 elif vcs == "svn":
-                    print("Updating Git SVN external: %s" % repo)
+                    log.info("Updating Git SVN external: %s" % repo)
                     call(["svn", "up"], cwd=path)
                 else:
                     cur_branch = run(["git", "symbolic-ref", "--short", "HEAD"],
                                      cwd=path, capture_output=True)
                     if cur_branch.stdout.decode().strip() == config.get("branch"):
-                        print(f"Updating Git external: {repo}")
+                        log.info(f"Updating Git external: {repo}")
                         call(["git", "pull", "--ff-only"], cwd=path)
                     else:
-                        print(f"Skipping update of Git external: {repo}")
+                        log.warning(f"Skipping update, different branch checked out: {repo}")
             elif 'clone' in repo_only and not self.is_repository(path):
                 # Clone that repo
                 if config.get("symlink"):
                     link = os.path.expanduser(config["symlink"])
-                    print(f"Cloning symlinked external: {repo}")
+                    log.info(f"Cloning symlinked external: {repo}")
                     assert os.path.exists(link), "Path does not exist"
                     if os.path.exists(path) and os.path.islink(path):
                         os.unlink(path)
                     os.symlink(link, path)
                 elif vcs == "git-svn":
-                    print(f"Cloning Git SVN external: {repo}")
+                    log.info(f"Cloning Git SVN external: {repo}")
                     check_call(["git", "svn", "clone", config["url"],
                                 path, "-r", "HEAD"])
                 elif vcs == "svn":
-                    print("Cloning SVN external: %s" % repo)
+                    log.info("Cloning SVN external: %s" % repo)
                     check_call(["svn", "checkout", config["url"],
                                 path, ])
                 else:
-                    print(f"Cloning Git external: {repo}")
-                    check_call(["git", "clone", config["url"], path])
                     branch = config.get("branch")
-                    print(f"  Switch to branch or tag: {branch}")
-                    check_call(["git", "checkout", branch],
-                               cwd=path)
+                    log.info(f"Cloning Git external: {repo} (branch: {branch})")
+                    check_call(["git", "clone", config["url"],
+                                "--branch", branch, path])
             # recursively call for externals
             if (args.recursive and vcs in ['git', 'git-svn'] and
                     set(repo_only) & set(['clone', 'update'])):
-                print(f"Updating externals of {repo}")
+                log.info(f"Updating externals of {repo}")
                 ext = GitExternal(path=path)
                 ext.cmd_update(namedtuple('Args',
                                           ['recursive', 'automatic', 'external', 'only'])
@@ -322,7 +331,7 @@ class GitExternal:
 
             if config.get("run-init", "").lower() == "true":
                 init = os.path.join(path, "init")
-                print(init)
+                log.info(f"Running init: {init}")
                 if os.path.exists(init):
                     call(init, cwd=path)
 


### PR DESCRIPTION
This commit does two things:
- Never modify the current subproject, if the branch is not the one that
  is specified in the .gitexternals file. This is mostly the same
  behavior as before except one special case: A local branch is checked out
  and a new (never checked out locally) remote branch is specified in
  .gitexternals. Before this commit the branch is switched. This commit
  also corrects the log messages for this case.
- Support for arbitrary pathspecs (e.g. Git tags or commit hashes) as
  branch specification. Basically everything that `git checkout`
  supports is supported as well.