### PR TITLE
README: Update URL since file was moved in 16a4219

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ exists only one instance of it that is always symlinked.
 
 1. Install `git-external` into your git repo as `./init`
 
-         wget https://raw.githubusercontent.com/stettberger/git-external/master/git-external -O init
+         wget https://raw.githubusercontent.com/stettberger/git-external/master/bin/git-external -O init
          chmod u+x init
 
 2. Add an external repository


### PR DESCRIPTION
`git-external` was moved in 16a42199701dc8c5a83f0609cd9e9a217cb213d4 such that the [old URL](https://raw.githubusercontent.com/stettberger/git-external/master/git-external) gives error 404.