### PR TITLE
fix: catch non-zero exit of update/pull calls

### DIFF
--- a/bin/git-external
+++ b/bin/git-external
@@ -319,16 +319,16 @@ class GitExternal:
 
                 if vcs == "git-svn":
                     log.info(f"[{repo}] Updating GIT-SVN external")
-                    call(["git", "svn", "rebase"], cwd=path)
+                    check_call(["git", "svn", "rebase"], cwd=path)
                 elif vcs == "svn":
                     log.info("[{repo}] Updating Git SVN external")
-                    call(["svn", "up"], cwd=path)
+                    check_call(["svn", "up"], cwd=path)
                 else:
                     cur_branch = self.get_branch_name(path)
                     branch = config.get("branch") or "master"
                     if branch == cur_branch:
                         log.info(f"[{repo}] Updating Git external")
-                        call(["git", "pull", "--ff-only"], cwd=path)
+                        check_call(["git", "pull", "--ff-only"], cwd=path)
                     elif cur_branch is None:
                         log.warning(f"[{repo}] Skipping update, detached HEAD")
                     else:
@@ -379,7 +379,7 @@ class GitExternal:
                                    cwd=path)
 
             # recursively call for externals
-            if (args.recursive and vcs in ['git', 'git-svn'] and
+            if (recursive and vcs in ['git', 'git-svn'] and
                     set(repo_only) & set(['clone', 'update'])):
                 log.info(f"[{repo}] Updating recursive externals")
                 ext = GitExternal(path=path)


### PR DESCRIPTION
The `update` branch of `init_or_update` used `call` instead of `check_call` on the external programs, thus missing non-zero exit codes.

(And the check below checked the CLI arg `recursive`, not the (same-value) function parameter of the same name.)
