### PR TITLE
Decode and strip the hook directory path earlier

### DIFF
--- a/bin/git-external
+++ b/bin/git-external
@@ -398,7 +398,8 @@ class GitExternal:
         merge/pull.
         """
         hook_dir = check_output(["git", "rev-parse", "--git-path", "hooks"])
-        hook = os.path.join(hook_dir.decode().strip(), "post-merge")
+        hook_dir = hook_dir.decode().strip()
+        hook = os.path.join(hook_dir, "post-merge")
         if os.path.exists(hook_dir) and not os.path.exists(hook):
             with open(hook, "w+") as fd:
                 fd.write("#!/bin/sh\n\n")


### PR DESCRIPTION
Since f2cd305 the install_hook function is broken, as it uses the raw `git rev-parse --git-path hooks` output to check whether the hook directory exists. Decode and strip the path before using it.