### PR TITLE
Integrate sparse checkout support and bump minimum Python version to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ configured branch, use `./git-external clone`.
                 url = "${ibrvsscloud}/foo"	
                 path = "foo"
                 vcs = none
-- `script = none`: Execute a script after cloning the external
+- `script = none`: Execute a script located at repository root after cloning the external.  Note: not supported on Windows (including git-bash).
 
         [external "foo"]
                 script = run.sh
@@ -108,6 +108,13 @@ configured branch, use `./git-external clone`.
         [external "foo"]
                ...
                updateArgs = --sparse
+
+- `sparseCheckout`: Enable and configure sparse checkout.  If this option is not present or is empty, sparse checkout is disabled.  Note, `--sparse` option to `cloneArgs` or `updateArgs` is not required for this to work.
+
+        [external "foo"]
+               ...
+               sparseCheckout = "bar baz"
+
 
 ## Overrides
 

--- a/bin/git-external
+++ b/bin/git-external
@@ -304,6 +304,20 @@ class GitExternal:
         ret = cur_branch.stdout.decode().strip()
         return ret or None
 
+    def update_sparse_checkout(self, repo, path, config):
+        """Updates the current set of sparse checkouts"""
+        sparse_checkout = get_args(config, "sparseCheckout")
+        cur_dir = os.curdir
+        os.chdir(path)
+        if sparse_checkout:
+            log.info(f"[{repo}] Setting sparse-checkout to {sparse_checkout}")
+            cmd = ["git", "sparse-checkout", "set"] + sparse_checkout     
+        else:
+            log.info(f"[{repo}] Sparse checkout not in use, disabled")        
+            cmd = ["git", "sparse-checkout", "disable"]
+        check_call(cmd)
+        os.chdir(cur_dir)
+
     def init_or_update(self, recursive=True, only=None, external=None):
         """Init or update all repositories in self.configurations.
 
@@ -355,6 +369,7 @@ class GitExternal:
                         opts = get_args(config, "updateArgs")
                         log.info(f"[{repo}] Updating Git external, {opts}")
                         check_call(["git", "pull", "--ff-only"] + opts, cwd=path)
+                        self.update_sparse_checkout(repo, path, config)
                     elif cur_branch is None:
                         log.warning(f"[{repo}] Skipping update, detached HEAD")
                     else:
@@ -407,6 +422,9 @@ class GitExternal:
                     cmd = ["git", "clone"] + opts + [config["url"], path]
                     print(" ".join(cmd))
                     check_call(cmd)
+
+                    #if "--sparse" in opts:
+                    self.update_sparse_checkout(repo, path, config)
 
                     cur_branch = self.get_branch_name(path)
                     branch = config.get('branch') or "master"

--- a/bin/git-external
+++ b/bin/git-external
@@ -422,10 +422,7 @@ class GitExternal:
                     cmd = ["git", "clone"] + opts + [config["url"], path]
                     print(" ".join(cmd))
                     check_call(cmd)
-
-                    #if "--sparse" in opts:
                     self.update_sparse_checkout(repo, path, config)
-
                     cur_branch = self.get_branch_name(path)
                     branch = config.get('branch') or "master"
                     if cur_branch != branch:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(name='git-external',
       ],
       zip_safe=False,
       scripts=['bin/git-external'],
-      python_requires='>=3.6'
+      python_requires='>=3.7'
 )
 


### PR DESCRIPTION
First, thank you for a very useful utility!

This change set adds integrated support for a `sparseCheckout` option that directly performs a sparse checkout of the listed directories.

While attempting to use the git-external to do a sparse checkout, I originally tried a combination of `cloneArgs` and `script` support.  This was OK on Linux, however I found that colleagues using Windows were unable to use `script` as Windows only allows running executables.  Instead, I made these changes which let git-external itself set up the sparse-checkout.  This both works on Windows and eliminates the need for a separate script, so it is cleaner.

I updated the usage info in the README to include the new option, also noting that `script` does not work on Windows.  I also bumped the minimum Python to 3.7 in `setup.py` because the `capture_output` parameter for subprocess was introduced in 3.7; I discovered this when running on an old Ubuntu 18 system with Python 3.6.